### PR TITLE
Feature/wait header

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ responds with a non-error response on a configured HTTP endpoint.
     if you don't configure it at all.
 * `SIGSCI_WAIT_TIMEOUT`: (optional) defaults to 60 seconds. if your app's "wait endpoint" doesn't respond
     within this time, the container will stop with an error code.
+* `SIGSCI_WAIT_HEADER`: (optional) include a custom header line in the wait HTTP request. useful if, for
+    example, your application uses `X-Forwarded-Proto: https` to enforce HTTPS connections.
 
 Example Python Dockerfile:
 
@@ -77,6 +79,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV APP_PORT=2000
 ENV SIGSCI_WAIT_ENDPOINT=ht
+ENV SIGSCI_WAIT_HEADER="X-Forwarded-Proto: https"
 CMD [ "poetry", "run", "python", "runserver.py", "0:${APP_PORT}" ]
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ upstreams = \"http://127.0.0.1:${APP_PORT}\"
 
 UPSTREAM_URL="http://127.0.0.1:${APP_PORT}/${SIGSCI_WAIT_ENDPOINT:-}"
 echo "waiting for ${UPSTREAM_URL} to respond..."
-wait-for "${UPSTREAM_URL}" --timeout "${SIGSCI_WAIT_TIMEOUT:-60}" --header "${SIGSCI_WAIT_HEADER}"
+wait-for "${UPSTREAM_URL}" --timeout "${SIGSCI_WAIT_TIMEOUT:-60}" --header "${SIGSCI_WAIT_HEADER:-}"
 
 echo "starting sigsci-agent..."
 /usr/sbin/sigsci-agent --config "${CONFIG_FILE}" &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ upstreams = \"http://127.0.0.1:${APP_PORT}\"
 
 UPSTREAM_URL="http://127.0.0.1:${APP_PORT}/${SIGSCI_WAIT_ENDPOINT:-}"
 echo "waiting for ${UPSTREAM_URL} to respond..."
-wait-for "${UPSTREAM_URL}" --timeout "${SIGSCI_WAIT_TIMEOUT:-60}"
+wait-for "${UPSTREAM_URL}" --timeout "${SIGSCI_WAIT_TIMEOUT:-60}" --header "${SIGSCI_WAIT_HEADER}"
 
 echo "starting sigsci-agent..."
 /usr/sbin/sigsci-agent --config "${CONFIG_FILE}" &

--- a/wait-for/README.md
+++ b/wait-for/README.md
@@ -6,8 +6,8 @@ https://github.com/Eficode/wait-for
 
 (MIT license)
 
-We use it to wait for the main application to be able to respond to requests. When the main application is responding,
-we then launch the SigSci agent.
+We use it to wait for the main application to be able to respond to requests. When the main application is
+responding, we then launch the SigSci agent.
 
 To update the script, do something like this:
 
@@ -15,3 +15,6 @@ To update the script, do something like this:
 wget "https://github.com/eficode/wait-for/releases/download/v${VERSION}/wait-for"
 chmod +x wait-for
 ```
+
+However we added our own `--header` parameter for our particular use case. Check `git diff` when you update
+the script.

--- a/wait-for/wait-for
+++ b/wait-for/wait-for
@@ -42,6 +42,7 @@ Usage:
   -q | --quiet                        Do not output any status messages
   -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
                                       Defaults to 15 seconds
+  -h HEADER | --header=header         Send a custom header line with the request
   -v | --version                      Show the version of this tool
   -- COMMAND ARGS                     Execute command with args after the test finishes
 USAGE
@@ -72,7 +73,7 @@ wait_for() {
         nc -w 1 -z "$HOST" "$PORT" > /dev/null 2>&1
         ;;
       http)
-        wget --timeout=1 --tries=1 -q "$HOST" -O /dev/null > /dev/null 2>&1
+        wget --timeout=1 --tries=1 -q "$HOST" -O /dev/null --header "$HEADER" > /dev/null 2>&1
         ;;
       *)
         echoerr "Unknown protocol '$PROTOCOL'"
@@ -147,6 +148,18 @@ while :; do
     ;;
     --timeout=*)
     TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    -h | --header)
+    HEADER="$2"
+    shift 2
+    ;;
+    -h*)
+    HEADER="${1#-h}"
+    shift 1
+    ;;
+    --header=*)
+    HEADER="${1#*=}"
     shift 1
     ;;
     --)


### PR DESCRIPTION
We have applications that assume they are sitting behind a trusted reverse proxy, so they check the `X-Forwarded-Proto` header as part of the logic to enforce HTTPS-only connections.

This allows users of the container to set an arbitrary header (`X-Forwarded-Proto` is just an example) to the `SIGSCI_WAIT_ENDPOINT`.
