### PR TITLE
handle TTY sessions for better debuggability

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,20 @@ if [ "${#}" -eq 0 ]; then
     exit 1
 fi
 
+if tty --silent; then
+    # the user is likely trying to run an interactive shell in the container. example commands that
+    # might get us here:
+    #
+    # * docker compose run my-service /bin/bash
+    # * docker run --rm -it my-image /bin/bash
+    # * heroku run --app my-app -- /bin/bash
+    #
+    # we don't want to wait for the upstream app to start, etc. just execute the command (ex:
+    # `/bin/bash` above) and exit.
+    "${@}"
+    exit ${?}
+fi
+
 APP_PORT="${APP_PORT:-2000}"
 
 if [ "${APP_PORT}" -eq "${PORT}" ]; then


### PR DESCRIPTION
if you have a heroku app that's based on this container, running this command...

```
heroku run --app my-super-cool-app -- /bin/bash
```

... results in this:

```
Running /bin/bash on ⬢ my-super-cool-app... up, run.1072
waiting for http://127.0.0.1:2000/version to respond...
http://127.0.0.1:2000/version failed to respond after 60 seconds.
```

so the entrypoint script is working, but now it expects _`/bin/bash`_ to respond on port 2000. since it doesn't, you get booted out of your app's shell after 60 seconds.

not good for debugging things. this change detects if we're trying to login with a TTY, and just executes whatever command we want without starting the sigsci agent.