### PR TITLE
Feature/disable firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ running when it responds with a non-error response on a configured HTTP endpoint
     configure it at all.
 * `SIGSCI_WAIT_TIMEOUT`: (optional) defaults to `60` seconds. if your app's "wait endpoint" doesn't
     respond within this time, the container will stop with an error code.
+* `SIGSCI_DISABLE`: (optional) useful for local development. set this environment variable to
+    anything, and it will just run your app without the firewall.
 
 Example Python Dockerfile:
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ running when it responds with a non-error response on a configured HTTP endpoint
     configure it at all.
 * `SIGSCI_WAIT_TIMEOUT`: (optional) defaults to `60` seconds. if your app's "wait endpoint" doesn't
     respond within this time, the container will stop with an error code.
-* `SIGSCI_DISABLE`: (optional) useful for local development. set this environment variable to
-    anything, and it will just run your app without the firewall.
+* `SIGSCI_STATUS`: (optional) defaults to `enabled`. set this environment variable to `disabled`
+    and it will just run your app without the firewall. _In this case the container will change
+    the `APP_PORT` env variable to match `PORT` if `PORT` is defined._
 
 Example Python Dockerfile:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,16 +6,18 @@ if [ "${#}" -eq 0 ]; then
     exit 1
 fi
 
-if tty --silent; then
-    # the user is likely trying to run an interactive shell in the container. example commands that
-    # might get us here:
+if tty --silent || [ "${SIGSCI_DISABLE+is_set}" == "is_set" ]; then
+    # either:
     #
-    # * docker compose run my-service /bin/bash
-    # * docker run --rm -it my-image /bin/bash
-    # * heroku run --app my-app -- /bin/bash
+    # * the user is trying to disable the firewall during local development (for example)
+    # * the user is attaching a TTY (interactive shell) to the container. example commands that
+    #   might do that:
+    #     * docker compose run my-service /bin/bash
+    #     * docker run --rm -it my-image /bin/bash
+    #     * heroku run --app my-app -- /bin/bash
     #
-    # we don't want to wait for the upstream app to start, etc. just execute the command (ex:
-    # `/bin/bash` above) and exit.
+    # in either case, we don't want to wait for the upstream app to start, initialize the sigsci
+    # agent, etc. just execute the command (ex: `/bin/bash`) and exit.
     "${@}"
     exit ${?}
 fi


### PR DESCRIPTION
introduce `SIGSCI_STATUS` (`enabled` or `disabled`)

when disabled, the agent doesn't run and the upstream application is configured to listen on `PORT` instead of `APP_PORT`.

useful for local development (at least)