### PR TITLE
Add support for Java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         version:
           - "21"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build Java container
         run: make java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,26 @@ jobs:
           creds: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
           image: ghcr.io/thermondo/sigsci
+
+  build-java:
+    runs-on: ubuntu-22.04
+    needs: lint
+    strategy:
+      matrix:
+        version:
+          - "21"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Java container
+        run: make java
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+
+      - name: Publish
+        uses: thermondo/gce-docker-push-action@a51e08b0f3c379d26d65e327ce0271aa21ecd50c
+        with:
+          username: ${{ github.repository_owner }}
+          creds: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          image: ghcr.io/thermondo/sigsci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         version:
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-# https://docs.fastly.com/signalsciences/install-guides/agent-installation/ubuntu-agent/
+# https://docs.fastly.com/en/ngwaf/installing-the-agent-on-ubuntu
+# https://docs.fastly.com/en/ngwaf/installing-the-agent-on-debian
 ARG BASE_IMAGE
 
 # we're allowing the CI process to tag our image explicitly
@@ -8,13 +9,17 @@ LABEL org.opencontainers.image.source="https://github.com/thermondo/sigsci-conta
 ARG DEBIAN_FRONTEND=noninteractive
 SHELL [ "/bin/bash", "-Eeuo", "pipefail", "-c" ]
 
+# sometimes we're working with a debian base image, sometimes we're working with an ubuntu base
+# image. this requires customizing our APT source a little bit, which we can do via build args.
+ARG APT_SOURCE
+
 # Don't want to pin apt package versions (yet... TODO perhaps)
 # hadolint ignore=DL3008
 RUN \
 apt-get update; \
 apt-get install --yes --no-install-recommends apt-transport-https curl gnupg ca-certificates; \
 curl --silent --fail --show-error --location https://apt.signalsciences.net/release/gpgkey | gpg --dearmor -o /usr/share/keyrings/sigsci.gpg; \
-echo "deb [signed-by=/usr/share/keyrings/sigsci.gpg] https://apt.signalsciences.net/release/ubuntu/ jammy main" > /etc/apt/sources.list.d/sigsci-release.list; \
+echo "deb [signed-by=/usr/share/keyrings/sigsci.gpg] ${APT_SOURCE}" > /etc/apt/sources.list.d/sigsci-release.list; \
 apt-get update; \
 apt-get install --yes --no-install-recommends sigsci-agent; \
 apt-get clean; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON_VERSION?=3.12
+JAVA_VERSION?=21
 
 all: lint general python
 .PHONY: all
@@ -9,6 +10,7 @@ general:
 		--tag "localhost/thermondo-sigsci" \
 		--tag "ghcr.io/thermondo/sigsci" \
 		--build-arg "BASE_IMAGE=debian:bookworm-slim" \
+		--build-arg "APT_SOURCE=https://apt.signalsciences.net/release/debian/ bookworm main" \
 		.
 .PHONY: general
 
@@ -18,8 +20,19 @@ python:
 		--tag "localhost/thermondo-sigsci:python-${PYTHON_VERSION}" \
 		--tag "ghcr.io/thermondo/sigsci:python-${PYTHON_VERSION}" \
 		--build-arg "BASE_IMAGE=python:${PYTHON_VERSION}-slim" \
+		--build-arg "APT_SOURCE=https://apt.signalsciences.net/release/debian/ bookworm main" \
 		.
 .PHONY: python
+
+java:
+	docker build \
+		--pull \
+		--tag "localhost/thermondo-sigsci:jre-${JAVA_VERSION}" \
+		--tag "ghcr.io/thermondo/sigsci:jre-${JAVA_VERSION}" \
+		--build-arg "BASE_IMAGE=eclipse-temurin:${JAVA_VERSION}-jre-jammy" \
+		--build-arg "APT_SOURCE=https://apt.signalsciences.net/release/ubuntu/ jammy main" \
+		.
+.PHONY: java
 
 lint:
 	hadolint Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_VERSION?=3.11
+PYTHON_VERSION?=3.12
 
 all: lint general python
 .PHONY: all


### PR DESCRIPTION
* adds new image with `jre-21` tag (latest LTS Java release)
* adds new `python-3.12` tag
* fixes a minor incorrect `apt` configuration we had (were using an ubuntu package repo for a debian OS)

unfortunately, the eclipse temurin base container doesn't support debian, just ubuntu. so to support our existing debian bookworm-based python image alongside the ubuntu-based java image, we need to make the `apt` source a docker build arg.