### PR TITLE
log when a signal is forwarded to child process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,7 @@ CHILD_PID=${!}
 # gracefully shutdown if needed
 on_signal_received() {
     local signal_name="${1}"
+    log "Sending ${signal_name} to child PID ${CHILD_PID}..."
     kill -s "${signal_name}" "${CHILD_PID}"
     wait "${CHILD_PID}" || true
 }


### PR DESCRIPTION
if you have a child process that doesn't die, it can be helpful to know that, yes, the TERM or INT signal _is_ being forwarded to it.

here's what it looks like when i spam my terminal with Ctrl + C (shows as `^C`)

```
SIGSCI: starting sigsci-agent...
2023/12/12 13:02:53.671910 Signal Sciences Agent 4.49.0 starting as user root with PID 352, nice=12, Max open files=1048576, Max data size=unlimited, Max address space=unlimited, Max stack size=8388608
2023/12/12 13:02:53.673132 Starting 1 reverse proxy listeners
2023/12/12 13:02:53.673137 Starting "app" HTTP reverse proxy (http://0.0.0.0:8081 <=> http://127.0.0.1:8000)
2023/12/12 13:02:53.673387 Reverse proxy services started in 10.631445ms
2023/12/12 13:02:53.673831 =====================================================
2023/12/12 13:02:53.673834 Agent:     6b905ce063a7
2023/12/12 13:02:53.673835 System:    debian 12.2 (linux 6.5.6-76060506-generic)
2023/12/12 13:02:53.673836 Memory:    22.164G / 31.040G RAM available
2023/12/12 13:02:53.673837 CPU:       10 MaxProcs / 20 CPU cores available
2023/12/12 13:02:53.673838 =====================================================
2023/12/12 13:02:53.921588 Updated "datacenters" data: 2023.11.3+162557
2023/12/12 13:02:53.945627 Enabling request processing
^CSIGSCI: Sending SIGINT to child PID 345...
2023/12/12 13:03:04.550946 Received interruption signal. Shutting down
2023/12/12 13:03:04.551005 Shutting down 1 reverse proxy listeners gracefully...
2023/12/12 13:03:04.551199 Shutdown "app" reverse proxy (http://0.0.0.0:8081)
2023/12/12 13:03:04.786304 Signal Sciences Agent 4.49.0 stopped
^CSIGSCI: Sending SIGINT to child PID 345...
^CSIGSCI: Sending SIGINT to child PID 345...
^CSIGSCI: Sending SIGINT to child PID 345...
```