### PR TITLE
More robust process management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ARG APT_SOURCE
 # hadolint ignore=DL3008
 RUN \
 apt-get update; \
-apt-get install --yes --no-install-recommends apt-transport-https curl gnupg ca-certificates; \
+apt-get install --yes --no-install-recommends \
+    apt-transport-https curl gnupg ca-certificates tini; \
 curl --silent --fail --show-error --location https://apt.signalsciences.net/release/gpgkey | gpg --dearmor -o /usr/share/keyrings/sigsci.gpg; \
 echo "deb [signed-by=/usr/share/keyrings/sigsci.gpg] ${APT_SOURCE}" > /etc/apt/sources.list.d/sigsci-release.list; \
 apt-get update; \
@@ -27,4 +28,7 @@ rm -rf /var/lib/apt/lists/*;
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT [ "/entrypoint.sh" ]
+# tell tini to forward signals to ALL processes, not just the immediate child
+ENV TINI_KILL_PROCESS_GROUP=1
+
+ENTRYPOINT [ "/usr/bin/tini", "-vvv", "--", "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ rm -rf /var/lib/apt/lists/*;
 COPY entrypoint.sh /entrypoint.sh
 
 # tell tini to forward signals to ALL processes, not just the immediate child
+# don't be fooled by the env variable name; this makes tini forward ALL signals
+# to ALL processes.
 ENV TINI_KILL_PROCESS_GROUP=1
 
 ENTRYPOINT [ "/usr/bin/tini", "-vvv", "--", "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,9 @@ COPY entrypoint.sh /entrypoint.sh
 # to ALL processes.
 ENV TINI_KILL_PROCESS_GROUP=1
 
-ENTRYPOINT [ "/usr/bin/tini", "-vvv", "--", "/entrypoint.sh" ]
+# tell tini to reap all child processes, even if the host started the container
+# with the --init flag (causing our tini instance to no longer be PID 1).
+ENV TINI_SUBREAPER=1
+ENV TINI_VERBOSITY=3
+
+ENTRYPOINT [ "/usr/bin/tini", "--", "/entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ lint:
 	hadolint Dockerfile
 	shellcheck *.sh
 .PHONY: lint
+
+shell: general
+	docker run --rm -it --env SIGSCI_STATUS=disabled localhost/thermondo-sigsci /bin/bash
+.PHONY: shell

--- a/README.md
+++ b/README.md
@@ -91,3 +91,5 @@ CMD [ "poetry", "run", "python", "runserver.py", "0:${APP_PORT}" ]
     the sigsci agent after your app is up and running. This means you should not use `ENTRYPOINT` in your own
     Dockerfile unless you know what you're doing. If you use [CMD](https://docs.docker.com/engine/reference/builder/#cmd)
     instead, the base image's entrypoint script will execute that command for you.
+* This is a multi-service container. See [process management docs](doc/process-management.md) to
+    learn what our strategy is for doing this well.

--- a/doc/process-management.md
+++ b/doc/process-management.md
@@ -1,0 +1,39 @@
+# Process Management
+
+This is a [multi-service container](https://docs.docker.com/config/containers/multi-service_container/)
+for various reasons (which we won't get into here). It runs at least two processes:
+
+1. your application
+2. the sigsci agent
+
+If not done correctly, this could cause issues with stopping the container, handling crashes, etc.
+
+There are two main scenarios we need to handle:
+
+## Crashing apps
+
+If your application, or the sigsci agent crashes, we need to go ahead and kill the container. This
+is an easy problem to solve in `entrypoint.sh`: at the end of the script just use `wait -n` to
+wait for a single process to end, and then `exit` the script.
+
+## Handling signals
+
+By default when you use a bash script (like our `entrypoint.sh` script) to launch subprocesses, any
+signals that the container receives will go to bash. Unfortunately bash doesn't handle signals at
+all, much less forward them on to its child processes. You can fix this using `trap` in your
+script, however that adds a bit more complexity and room for bugs.
+
+This is why we use [tini](https://github.com/krallin/tini) as a [process supervisor](https://en.wikipedia.org/wiki/Process_supervision).
+It is configured to be our `ENTRYPOINT` so it will be PID 1 inside the container. It is also
+configured to forward signals to ALL subprocesses that are spawned underneath it, not just the first
+child subprocess (which is `bash` in this case).
+
+That means when the container gets a SIGTERM, SIGINT, etc., that signal is passed to `tini`, which
+then forwards the signal to ALL of:
+
+* bash (which does nothing)
+* your app
+* the sigsci agent
+
+If this signal causes ANY of these child processes to exit, that will cause bash to exit, which will
+cause `tini` to exit, and that is ultimately what stops the container.

--- a/doc/process-management.md
+++ b/doc/process-management.md
@@ -37,3 +37,11 @@ then forwards the signal to ALL of:
 
 If this signal causes ANY of these child processes to exit, that will cause bash to exit, which will
 cause `tini` to exit, and that is ultimately what stops the container.
+
+## Why not use docker's `--init` flag?
+
+`docker run --init` does essentially the same thing we are doing with `tini`. Docker even _uses
+`tini` internally._
+
+The reason we set up `tini` manually is because we aren't always in control of how the container is
+started, and we want it to work regardless of whether you use `--init` or not.


### PR DESCRIPTION
When the container receives a signal, we manually forward those signals to child processes with a bit of bash `trap` logic.

_(Only SIGINT and SIGTERM... other signals are ignored)_

This is a bit hacky, and really requires that we know what we're doing.

This change replaces that bash hackery with a proper :monocle_face: process supervisor, [tini](https://github.com/krallin/tini).

Full explanation in `doc/process-management.md` -- that's probably the best place to start looking at this PR.

## testing

recommended that we do a full test with a couple of our containers in heroku before merging this. but to test locally:

in one terminal, build and start your container:

```bash
make python
docker run --rm -it \
  --env PORT=8080 \
  --env APP_PORT=8000 \
  --env SIGSCI_ACCESSKEYID=$SIGSCI_ACCESSKEYID \
  --env SIGSCI_SECRETACCESSKEY=$SIGSCI_SECRETACCESSKEY \
  localhost/thermondo-sigsci:python-3.12 \
  python3 -m http.server
```

in another terminal, attach to the running container and start sending signals to various processes to see what happens:

```bash
docker exec -it "$(docker container ls --latest --quiet)" /bin/bash

# install `ps`, `kill`, etc.
apt update && apt install --yes procps

# see what processes are running
ps -e

# send signals to those processes
kill 1
```

if you try to kill the `bash` process, nothing will happen. but if you kill `python3`, `tini`, or `sigsci-agent`, then the container should exit.

_alternatively, instead of `docker exec`, you can try stopping the container:_

```bash
docker stop "$(docker container ls --latest --quiet)" --time 999
```

if the above command stops the container immediately, then you know it works. if it stops only after 999 seconds, then there's a problem.