### PR TITLE
chore: drop deprecated dependabot reviewers setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,4 @@ updates:
       interval: weekly
       day: "monday"
       time: "06:00"
-    reviewers:
-      - "thermondo/platform"
     open-pull-requests-limit: 20


### PR DESCRIPTION
GitHub deprecated the `reviewers` field on dependabot updates. CODEOWNERS already routes these PRs to `@thermondo/platform`, so removing the redundant setting.